### PR TITLE
Make VizHash stable 

### DIFF
--- a/tests/test_vizhash.py
+++ b/tests/test_vizhash.py
@@ -46,7 +46,15 @@ def test_identicon(seed, square_size, n):
     assert im.size == (n * square_size, n * square_size)
     assert im.mode == 'RGB'
 
+    
+@pytest.mark.parametrize('seed', some_strings)
+@pytest.mark.parametrize('n', some_sizes)
+@pytest.mark.parametrize('square_size', some_squares)
+def test_identicon_stability(seed, square_size, n):
+    vh = vizhash.Vizhash(seed, square_size, n)
+    assert vh.identicon() == vh.identicon()
 
+    
 @pytest.mark.parametrize('seed', some_strings)
 @pytest.mark.parametrize('n', some_sizes)
 @pytest.mark.parametrize('square_size', some_squares)

--- a/vizhash/vizhash.py
+++ b/vizhash/vizhash.py
@@ -16,6 +16,7 @@ class Vizhash:
         # Use the sha256 digest of the data to avoid collision on the
         # random generator
         seed = hashlib.sha256(data.encode("utf-8")).hexdigest()
+        self.seed = seed
         self.random = Random(seed)
 
     def _explore(self, i, j, cases, colors):
@@ -48,6 +49,7 @@ class Vizhash:
         return colors
 
     def identicon(self):
+        self.random.seed(self.seed)
         n = self.n
         colors = self._get_colors(n)
         size = (self.square_size * n, self.square_size * n)


### PR DESCRIPTION
Currently vizhash creates different images for the same input data each run. This patch fixes that by resetting the random number generator's state at the start of `VizHash.identicon()`.

Note: it's probably still not very accurate to describe this as a hashing function. It's dependent on the local system's random number generator, so won't create the same images from machine to machine.